### PR TITLE
Make entrypoint an absolute path.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN cd /go/src/github.com/deis/helloworld && go install -v .
 
 EXPOSE 80
 
-ENTRYPOINT ["helloworld"]
+ENTRYPOINT ["/go/bin/helloworld"]


### PR DESCRIPTION
Using deis 0.9.1 in a local development environment (vagrant) the example was failing to find the `helloworld` go executable.

For example:
`Jun 22 05:23:07 deis-1 sh[14724]: 2014/06/22 05:23:07 exec: "helloworld": executable file not found in $PATH`
