### PR TITLE
fix(Dockerfile): Use ubuntu:trusty image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
-FROM debian:jessie
+FROM ubuntu:trusty
+# Can be changed to deis/base after deis/base#7 is merged
 MAINTAINER OpDemand <info@opdemand.com>
 
 # install curl
 RUN apt-get update && apt-get install -qy curl
-
-# install go runtime
-RUN curl -s https://storage.googleapis.com/golang/go1.2.2.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN apt-get install -qy golang
 
 # prepare go environment
 ENV GOPATH /go
-ENV GOROOT /usr/local/go
-ENV PATH $PATH:/usr/local/go/bin:/go/bin
+ENV PATH $PATH:/go/bin
 
 # add the current build context
 ADD . /go/src/github.com/deis/helloworld


### PR DESCRIPTION
Ubuntu 14.04 is stable and has golang packaged natively. This means that the golang compiler and runtime binaries are signed and trusted by the Ubuntu team and you do not need to muck around with manually installing golang. This also means you use the common base of Ubuntu 14.04 and don't fill people's disks with Debian images [they may not use][LeastSurprise] (based on download count and tag numbers of `ubuntu` vs `debian`).

Additionally, this should be changed to `deis/base` after deis/base#7 is merged so that `helloworld` can be more consistent with the other parts of deis.

[LeastSurprise]: https://en.wikipedia.org/wiki/Principle_of_least_astonishment